### PR TITLE
Compatibility fix for django > 1.4 importing django constant LOOKUP_SEP

### DIFF
--- a/money/contrib/django/models/managers.py
+++ b/money/contrib/django/models/managers.py
@@ -9,7 +9,10 @@ __all__ = ('QuerysetWithMoney', 'MoneyManager',)
 class QuerysetWithMoney(QuerySet):
     
     def _update_params(self, kwargs):
-        from django.db.models.sql.constants import LOOKUP_SEP
+        try:
+            from django.db.models.sql.constants import LOOKUP_SEP
+        except ImportError:
+            from django.db.models.constants import LOOKUP_SEP  # Forward compatibility for Django > 1.4
         from money import Money
         to_append = {}
         for name, value in kwargs.items():


### PR DESCRIPTION
LOOKUP_SEP settings has been moved in "django.db.models.constants" from django 1.5
