### PR TITLE
Fix a typing issue with the currency sub field

### DIFF
--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -67,7 +67,7 @@ class MoneyFieldProxy(object):
         if value is None: # Money(0) is False
             self._set_values(obj, None, '')
         elif isinstance(value, Money):
-            self._set_values(obj, value.amount, value.currency)
+            self._set_values(obj, value.amount, value.currency.code)
         elif isinstance(value, Decimal):
             _, currency = self._get_values(obj) # use what is currently set
             self._set_values(obj, value, currency)

--- a/money/money.py
+++ b/money/money.py
@@ -91,10 +91,10 @@ class Money(object):
         s = str(value).strip()
         try:
             amount = Decimal(s)
-            currency = DEFAULT_CURRENCY
+            currency = DEFAULT_CURRENCY.code
         except:
             try:
-                currency = CURRENCY[s[:3].upper()]
+                currency = CURRENCY[s[:3].upper()].code  # assert that the substring is a correct currency
                 amount = Decimal(s[3:].strip())
             except:
                 raise IncorrectMoneyInputError("The value '%s' is not properly formatted as 'XXX 123.45' " % s)

--- a/money/money.py
+++ b/money/money.py
@@ -91,10 +91,10 @@ class Money(object):
         s = str(value).strip()
         try:
             amount = Decimal(s)
-            currency = DEFAULT_CURRENCY.code
+            currency = DEFAULT_CURRENCY
         except:
             try:
-                currency = CURRENCY[s[:3].upper()].code  # assert that the substring is a correct currency
+                currency = CURRENCY[s[:3].upper()]
                 amount = Decimal(s[3:].strip())
             except:
                 raise IncorrectMoneyInputError("The value '%s' is not properly formatted as 'XXX 123.45' " % s)


### PR DESCRIPTION
In certain instances, the currency subfield (`total_currency` for example) could be of type `Currency` instead of a string-like.
