### PR TITLE
Switch ugettext to gettext

### DIFF
--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -67,7 +67,7 @@ class MoneyFieldProxy(object):
         if value is None: # Money(0) is False
             self._set_values(obj, None, '')
         elif isinstance(value, Money):
-            self._set_values(obj, value.amount, value.currency)
+            self._set_values(obj, value.amount, value.currency.code)
         elif isinstance(value, Decimal):
             _, currency = self._get_values(obj) # use what is currently set
             self._set_values(obj, value, currency)

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -256,11 +256,12 @@ class MoneyField(InfiniteDecimalField):
         defaults.update(kwargs)
         return super(MoneyField, self).formfield(**defaults)
 
+    @property
     def validators(self):
         # Hack around the fact that we inherit from DecimalField but don't hold
         # Decimals. The real fix is to stop inheriting from DecimalField. *Not*
         # recommending this for use in a production setting.
-        pass
+        return []
 
 
 # South introspection rules

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -256,6 +256,12 @@ class MoneyField(InfiniteDecimalField):
         defaults.update(kwargs)
         return super(MoneyField, self).formfield(**defaults)
 
+    def validators(self):
+        # Hack around the fact that we inherit from DecimalField but don't hold
+        # Decimals. The real fix is to stop inheriting from DecimalField. *Not*
+        # recommending this for use in a production setting.
+        pass
+
 
 # South introspection rules
 # (see http://south.aeracode.org/docs/customfields.html#extending-introspection)

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -259,8 +259,7 @@ class MoneyField(InfiniteDecimalField):
     @property
     def validators(self):
         # Hack around the fact that we inherit from DecimalField but don't hold
-        # Decimals. The real fix is to stop inheriting from DecimalField. *Not*
-        # recommending this for use in a production setting.
+        # Decimals. The real fix is to stop inheriting from DecimalField.
         return []
 
 

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -58,6 +58,8 @@ class MoneyFieldProxy(object):
         obj.__dict__[self.field.currency_field_name] = currency
 
     def __get__(self, obj, *args):
+        if obj is None:
+            return self
         amount, currency = self._get_values(obj)
         if amount is None:
             return None

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.db import models
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from money.contrib.django import forms
 from money.money import Money
@@ -133,7 +133,7 @@ class CurrencyField(models.CharField):
 
 
 class MoneyField(InfiniteDecimalField):
-    description = ugettext_lazy('An amount and type of currency')
+    description = gettext_lazy('An amount and type of currency')
 
     # Don't extend SubfieldBase since we need to have access to both fields when
     # to_python is called. We need our code there instead of subfieldBase

--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -128,7 +128,7 @@ class CurrencyField(models.CharField):
         When serializing, we want to output as two values. This will be just
         the currency part as stored directly in the database.
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value
 
 
@@ -250,7 +250,7 @@ class MoneyField(InfiniteDecimalField):
         Here we only need to output the value. The contributed currency field
         will get called to output itself
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.amount
 
     def formfield(self, **kwargs):

--- a/money/money.py
+++ b/money/money.py
@@ -361,7 +361,7 @@ CURRENCY['MAD'] = Currency(code='MAD', numeric='504', decimals=2, symbol=u'', na
 CURRENCY['MDL'] = Currency(code='MDL', numeric='498', decimals=2, symbol=u'', name=u'Moldovan Leu', countries=[u'MOLDOVA, REPUBLIC OF'])
 CURRENCY['MGA'] = Currency(code='MGA', numeric='969', decimals=2, symbol=u'', name=u'Malagasy Ariary', countries=[u'MADAGASCAR'])
 CURRENCY['MKD'] = Currency(code='MKD', numeric='807', decimals=2, symbol=u'ден', name=u'Denar', countries=[u'MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF'])
-CURRENCY['MMK'] = Currency(code='MMK', numeric='104', decimals=2, symbol=u'', name=u'Kyat', countries=[u'MYANMAR'])
+CURRENCY['MMK'] = Currency(code='MMK', numeric='104', decimals=2, symbol=u'K', name=u'Kyat', countries=[u'MYANMAR'])
 CURRENCY['MNT'] = Currency(code='MNT', numeric='496', decimals=2, symbol=u'₮', name=u'Tugrik', countries=[u'MONGOLIA'])
 CURRENCY['MOP'] = Currency(code='MOP', numeric='446', decimals=2, symbol=u'', name=u'Pataca', countries=[u'MACAO'])
 CURRENCY['MRO'] = Currency(code='MRO', numeric='478', decimals=2, symbol=u'', name=u'Ouguiya', countries=[u'MAURITANIA'])

--- a/money/money.py
+++ b/money/money.py
@@ -91,10 +91,10 @@ class Money(object):
         s = str(value).strip()
         try:
             amount = Decimal(s)
-            currency = DEFAULT_CURRENCY
+            currency = DEFAULT_CURRENCY.code
         except:
             try:
-                currency = CURRENCY[s[:3].upper()]
+                currency = CURRENCY[s[:3].upper()].code  # assert that the substring is a correct currency
                 amount = Decimal(s[3:].strip())
             except:
                 raise IncorrectMoneyInputError("The value '%s' is not properly formatted as 'XXX 123.45' " % s)

--- a/money/money.py
+++ b/money/money.py
@@ -91,10 +91,10 @@ class Money(object):
         s = str(value).strip()
         try:
             amount = Decimal(s)
-            currency = DEFAULT_CURRENCY.code
+            currency = DEFAULT_CURRENCY
         except:
             try:
-                currency = CURRENCY[s[:3].upper()].code  # assert that the substring is a correct currency
+                currency = CURRENCY[s[:3].upper()]
                 amount = Decimal(s[3:].strip())
             except:
                 raise IncorrectMoneyInputError("The value '%s' is not properly formatted as 'XXX 123.45' " % s)

--- a/money/tests/views.py
+++ b/money/tests/views.py
@@ -14,6 +14,7 @@ class TestForm(forms.Form):
 class TestModelForm(forms.ModelForm):
     class Meta:
         model = SimpleMoneyModel
+        fields = '__all__'
 
 
 def instance_view(request):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ keywords = 'money currency finance'.split()
 tests_require = [
     'pytest-django',
     'pytest-cov',
-    'django<1.9',
+    'django==1.9',
     'psycopg2',
     'six',
 ]
@@ -48,7 +48,7 @@ requirements = [
 ]
 
 extras_require = {
-    'django':  ['Django < 1.8', ],
+    'django':  ['Django==1.9', ],
 }
 
 dependency_links = []

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ keywords = 'money currency finance'.split()
 tests_require = [
     'pytest-django',
     'pytest-cov',
-    'django==1.9',
+    'django<1.10',
     'psycopg2',
     'six',
 ]
@@ -48,7 +48,7 @@ requirements = [
 ]
 
 extras_require = {
-    'django':  ['Django==1.9', ],
+    'django':  ['Django<1.10', ],
 }
 
 dependency_links = []


### PR DESCRIPTION
# Description
In order to upgrade Django to version 4.0, we need to replace instances of `ugettext*` with `gettext`

## Error message
```
hats-gunicorn    | Traceback (most recent call last):
hats-gunicorn    |   File "/opt/apps/./hats/manage.py", line 11, in <module>
hats-gunicorn    |     execute_from_command_line(sys.argv)
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
hats-gunicorn    |     utility.execute()
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 420, in execute
hats-gunicorn    |     django.setup()
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
hats-gunicorn    |     apps.populate(settings.INSTALLED_APPS)
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/django/apps/registry.py", line 116, in populate
hats-gunicorn    |     app_config.import_models()
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/django/apps/config.py", line 304, in import_models
hats-gunicorn    |     self.models_module = import_module(models_module_name)
hats-gunicorn    |   File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
hats-gunicorn    |     return _bootstrap._gcd_import(name[level:], package, level)
hats-gunicorn    |   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
hats-gunicorn    |   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
hats-gunicorn    |   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
hats-gunicorn    |   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
hats-gunicorn    |   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
hats-gunicorn    |   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
hats-gunicorn    |   File "/opt/apps/hats/accesscontrol/models.py", line 8, in <module>
hats-gunicorn    |     from makelibs.django import models
hats-gunicorn    |   File "/opt/apps/makelibs/django/models/__init__.py", line 46, in <module>
hats-gunicorn    |     from money.contrib.django.models.fields import MoneyField
hats-gunicorn    |   File "/opt/venv/lib/python3.9/site-packages/money/contrib/django/models/fields.py", line 4, in <module>
hats-gunicorn    |     from django.utils.translation import ugettext_lazy
hats-gunicorn    | ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation' (/opt/venv/lib/python3.9/site-packages/django/utils/translation/__init__.py)
```